### PR TITLE
Add links to toggle the search/login forms

### DIFF
--- a/src/cljs/gnar/state/gnar.cljs
+++ b/src/cljs/gnar/state/gnar.cljs
@@ -10,7 +10,9 @@
 
 (set! cljs.core/*print-fn* #(.log js/console %))
 
-(defc state {})
+;;; hide the login and search fields by default
+(defc state {:login-visible false
+             :search-visible false})
 (defc error nil)
 (defc loading [])
 
@@ -19,7 +21,10 @@
 (defc= loaded? (not= {} state))
 (defc= logged-in? (contains? state :current-user-id))
 (defc= logged-out? (not logged-in?))
-(defc= show-login? (and loaded? (not logged-in?)))
+(defc= show-login? (and (:login-visible state)
+                        loaded?
+                        (not logged-in?)))
+(defc= show-search? (:search-visible state))
 
 (defc= current-user-id (:current-user-id state))
 

--- a/src/hoplon/index.html.hl
+++ b/src/hoplon/index.html.hl
@@ -35,11 +35,13 @@
   <body>
     <header>
       <h1>gnar</h1>
+      <a on-click="{{ #(swap! gnar/state assoc :search-visible (not (:search-visible gnar/state))) }}" href="javascript:void(0)">search</a>
+      <a on-click="{{ #(swap! gnar/state assoc :login-visible (not (:login-visible gnar/state))) }}" href="javascript:void(0)">login</a>
       <nav>
         <ul>
           <li do-toggle="{{ (cell= false) }}"><a href="#">Home</a></li>
           <li do-toggle="{{ gnar/logged-in? }}"><a href="javascript:void(0);" on-click="{{ #(do (gnar/logout!)) }}">Logout</a></li>
-          <li><input type="text" id="search" placeholder="search"></li>
+          <li do-toggle="{{ gnar/show-search? }}"><input type="text" id="search" placeholder="search"></li>
         </ul>
       </nav>
       <div id="flash error">


### PR DESCRIPTION
Also: hide the search/login forms by default

Note: hiding the forms is really slow for some reason. Hoplon thing?

Fixes #6 (except for navigation styles)
